### PR TITLE
Remove unnecessary dependency on Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(savitar_HDRS
     src/MeshData.h
     src/Vertex.h
     src/Face.h
+    src/SavitarExport.h
 )
 
 set(SAVITAR_VERSION 0.1.0)

--- a/python/MeshData.sip
+++ b/python/MeshData.sip
@@ -24,12 +24,12 @@ class MeshData
 public:
     MeshData();
     virtual ~MeshData();
-    std::vector<uint8_t> getVerticesAsBytes();
-    std::vector<uint8_t> getFacesAsBytes();
+    bytearray getVerticesAsBytes();
+    bytearray getFacesAsBytes();
 
-    std::vector<uint8_t> getFlatVerticesAsBytes();
+    bytearray getFlatVerticesAsBytes();
 
-    void setVerticesFromBytes(const std::vector<uint8_t>& data);
+    void setVerticesFromBytes(const bytearray& data);
 
-    void setFacesFromBytes(const std::vector<uint8_t>& data);
+    void setFacesFromBytes(const bytearray& data);
 };

--- a/python/MeshData.sip
+++ b/python/MeshData.sip
@@ -24,12 +24,12 @@ class MeshData
 public:
     MeshData();
     virtual ~MeshData();
-    PyObject* getFacesAsBytes();
-    PyObject* getVerticesAsBytes();
+    std::vector<char> getVerticesAsBytes();
+    std::vector<char> getFacesAsBytes();
 
-    PyObject* getFlatVerticesAsBytes();
+    std::vector<char> getFlatVerticesAsBytes();
 
-    void setVerticesFromBytes(PyObject* py_bytes);
+    void setVerticesFromBytes(const std::vector<char> &data);
 
-    void setFacesFromBytes(PyObject* py_bytes);
+    void setFacesFromBytes(const std::vector<char> &data);
 };

--- a/python/MeshData.sip
+++ b/python/MeshData.sip
@@ -24,12 +24,12 @@ class MeshData
 public:
     MeshData();
     virtual ~MeshData();
-    std::vector<char> getVerticesAsBytes();
-    std::vector<char> getFacesAsBytes();
+    std::vector<uint8_t> getVerticesAsBytes();
+    std::vector<uint8_t> getFacesAsBytes();
 
-    std::vector<char> getFlatVerticesAsBytes();
+    std::vector<uint8_t> getFlatVerticesAsBytes();
 
-    void setVerticesFromBytes(const std::vector<char> &data);
+    void setVerticesFromBytes(const std::vector<uint8_t> &data);
 
-    void setFacesFromBytes(const std::vector<char> &data);
+    void setFacesFromBytes(const std::vector<uint8_t> &data);
 };

--- a/python/MeshData.sip
+++ b/python/MeshData.sip
@@ -29,7 +29,7 @@ public:
 
     std::vector<uint8_t> getFlatVerticesAsBytes();
 
-    void setVerticesFromBytes(const std::vector<uint8_t> &data);
+    void setVerticesFromBytes(const std::vector<uint8_t>& data);
 
-    void setFacesFromBytes(const std::vector<uint8_t> &data);
+    void setFacesFromBytes(const std::vector<uint8_t>& data);
 };

--- a/python/Types.sip
+++ b/python/Types.sip
@@ -168,15 +168,15 @@
  * Convert to and from byte arrays.
  * Uses the internal data vector directly to create/extract a PyBytes* instance.
  */
-template<char>
-%MappedType std::vector<char>
+%MappedType std::vector<uint8_t>
 {
     %TypeHeaderCode
     #include <vector>
+    #include <cstdint>
     %End
 
     %ConvertFromTypeCode // From C++ to python
-        return PyBytes_FromStringAndSize(sipCpp->data(), sipCpp->size());
+        return PyBytes_FromStringAndSize(reinterpret_cast<const char *>(sipCpp->data()), sipCpp->size());
     %End
 
     %ConvertToTypeCode // From python to C++
@@ -187,14 +187,14 @@ template<char>
 
         if (sipPy == Py_None)
         {
-            *sipCppPtr = new std::vector<char>;
+            *sipCppPtr = new std::vector<uint8_t>;
             return 1;
         }
 
         if (PyBytes_Check(sipPy))
         {
-            char *buffer = PyBytes_AS_STRING(sipPy);
-            *sipCppPtr = new std::vector<char>(buffer, buffer + PyBytes_GET_SIZE(sipPy));
+            uint8_t *buffer = reinterpret_cast<uint8_t *>(PyBytes_AS_STRING(sipPy));
+            *sipCppPtr = new std::vector<uint8_t>(buffer, buffer + PyBytes_GET_SIZE(sipPy));
             return 1;
         }
         return 0;

--- a/python/Types.sip
+++ b/python/Types.sip
@@ -165,6 +165,43 @@
 };
 
 /**
+ * Convert to and from byte arrays.
+ * Uses the internal data vector directly to create/extract a PyBytes* instance.
+ */
+template<char>
+%MappedType std::vector<char>
+{
+    %TypeHeaderCode
+    #include <vector>
+    %End
+
+    %ConvertFromTypeCode // From C++ to python
+        return PyBytes_FromStringAndSize(sipCpp->data(), sipCpp->size());
+    %End
+
+    %ConvertToTypeCode // From python to C++
+        if (sipIsErr == NULL)
+        {
+            return (PyBytes_Check(sipPy));
+        }
+
+        if (sipPy == Py_None)
+        {
+            *sipCppPtr = new std::vector<char>;
+            return 1;
+        }
+
+        if (PyBytes_Check(sipPy))
+        {
+            char *buffer = PyBytes_AS_STRING(sipPy);
+            *sipCppPtr = new std::vector<char>(buffer, buffer + PyBytes_GET_SIZE(sipPy));
+            return 1;
+        }
+        return 0;
+    %End
+};
+
+/**
  * SIP generic implementation for std::vector<TYPE>
  */
 template<TYPE>

--- a/python/Types.sip
+++ b/python/Types.sip
@@ -168,11 +168,12 @@
  * Convert to and from byte arrays.
  * Uses the internal data vector directly to create/extract a PyBytes* instance.
  */
-%MappedType std::vector<uint8_t>
+%MappedType bytearray
 {
     %TypeHeaderCode
     #include <vector>
     #include <cstdint>
+    #include "Types.h"
     %End
 
     %ConvertFromTypeCode // From C++ to python
@@ -187,14 +188,14 @@
 
         if (sipPy == Py_None)
         {
-            *sipCppPtr = new std::vector<uint8_t>;
+            *sipCppPtr = new bytearray;
             return 1;
         }
 
         if (PyBytes_Check(sipPy))
         {
             uint8_t *buffer = reinterpret_cast<uint8_t *>(PyBytes_AS_STRING(sipPy));
-            *sipCppPtr = new std::vector<uint8_t>(buffer, buffer + PyBytes_GET_SIZE(sipPy));
+            *sipCppPtr = new bytearray(buffer, buffer + PyBytes_GET_SIZE(sipPy));
             return 1;
         }
         return 0;

--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -45,7 +45,7 @@ void MeshData::clear()
 
 std::vector<uint8_t> MeshData::getVerticesAsBytes()
 {
-    std::vector<uint8_t> vertices_data;
+    std::vector<uint8_t> vertices_data(vertices.size() * sizeof(float) * 3);
 
     for(int i = 0; i < vertices.size(); i++)
     {
@@ -61,7 +61,7 @@ std::vector<uint8_t> MeshData::getVerticesAsBytes()
 
 std::vector<uint8_t> MeshData::getFlatVerticesAsBytes()
 {
-    std::vector<uint8_t> vertices_data;
+    std::vector<uint8_t> vertices_data(faces.size() * sizeof(float) * 3 * 3);
     for(int i = 0; i < faces.size(); i++)
     {
         int v1 = faces.at(i).getV1();
@@ -97,7 +97,7 @@ std::vector<uint8_t> MeshData::getFlatVerticesAsBytes()
 
 std::vector<uint8_t> MeshData::getFacesAsBytes()
 {
-    std::vector<uint8_t> face_data;
+    std::vector<uint8_t> face_data(faces.size() * sizeof(int) * 3);
 
     for(int i = 0; i < faces.size(); i++)
     {

--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -43,9 +43,9 @@ void MeshData::clear()
     this->vertices.clear();
 }
 
-std::vector<uint8_t> MeshData::getVerticesAsBytes()
+bytearray MeshData::getVerticesAsBytes()
 {
-    std::vector<uint8_t> vertices_data(vertices.size() * sizeof(float) * 3);
+    bytearray vertices_data(vertices.size() * sizeof(float) * 3);
 
     for(int i = 0; i < vertices.size(); i++)
     {
@@ -59,9 +59,9 @@ std::vector<uint8_t> MeshData::getVerticesAsBytes()
     return vertices_data;
 }
 
-std::vector<uint8_t> MeshData::getFlatVerticesAsBytes()
+bytearray MeshData::getFlatVerticesAsBytes()
 {
-    std::vector<uint8_t> vertices_data(faces.size() * sizeof(float) * 3 * 3);
+    bytearray vertices_data(faces.size() * sizeof(float) * 3 * 3);
     for(int i = 0; i < faces.size(); i++)
     {
         int v1 = faces.at(i).getV1();
@@ -95,9 +95,9 @@ std::vector<uint8_t> MeshData::getFlatVerticesAsBytes()
     return vertices_data;
 }
 
-std::vector<uint8_t> MeshData::getFacesAsBytes()
+bytearray MeshData::getFacesAsBytes()
 {
-    std::vector<uint8_t> face_data(faces.size() * sizeof(int) * 3);
+    bytearray face_data(faces.size() * sizeof(int) * 3);
 
     for(int i = 0; i < faces.size(); i++)
     {
@@ -132,7 +132,7 @@ void MeshData::toXmlNode(pugi::xml_node& node)
     }
 }
 
-void MeshData::setVerticesFromBytes(const std::vector<uint8_t>& data)
+void MeshData::setVerticesFromBytes(const bytearray& data)
 {
     vertices.clear();
     const uint8_t* bytes = data.data();
@@ -149,7 +149,7 @@ void MeshData::setVerticesFromBytes(const std::vector<uint8_t>& data)
     }
 }
 
-void MeshData::setFacesFromBytes(const std::vector<uint8_t>& data)
+void MeshData::setFacesFromBytes(const bytearray& data)
 {
     faces.clear();
     const uint8_t* bytes = data.data();

--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -132,7 +132,7 @@ void MeshData::toXmlNode(pugi::xml_node& node)
     }
 }
 
-void MeshData::setVerticesFromBytes(const std::vector<uint8_t> &data)
+void MeshData::setVerticesFromBytes(const std::vector<uint8_t>& data)
 {
     vertices.clear();
     const uint8_t* bytes = data.data();
@@ -149,7 +149,7 @@ void MeshData::setVerticesFromBytes(const std::vector<uint8_t> &data)
     }
 }
 
-void MeshData::setFacesFromBytes(const std::vector<uint8_t> &data)
+void MeshData::setFacesFromBytes(const std::vector<uint8_t>& data)
 {
     faces.clear();
     const uint8_t* bytes = data.data();

--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -43,25 +43,25 @@ void MeshData::clear()
     this->vertices.clear();
 }
 
-std::vector<char> MeshData::getVerticesAsBytes()
+std::vector<uint8_t> MeshData::getVerticesAsBytes()
 {
-    std::vector<char> vertices_data;
+    std::vector<uint8_t> vertices_data;
 
     for(int i = 0; i < vertices.size(); i++)
     {
         float x = vertices.at(i).getX();
         float y = vertices.at(i).getY();
         float z = vertices.at(i).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
     }
     return vertices_data;
 }
 
-std::vector<char> MeshData::getFlatVerticesAsBytes()
+std::vector<uint8_t> MeshData::getFlatVerticesAsBytes()
 {
-    std::vector<char> vertices_data;
+    std::vector<uint8_t> vertices_data;
     for(int i = 0; i < faces.size(); i++)
     {
         int v1 = faces.at(i).getV1();
@@ -72,41 +72,41 @@ std::vector<char> MeshData::getFlatVerticesAsBytes()
         float x = vertices.at(v1).getX();
         float y = vertices.at(v1).getY();
         float z = vertices.at(v1).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
 
         // Add vertices for face 2
         x = vertices.at(v2).getX();
         y = vertices.at(v2).getY();
         z = vertices.at(v2).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
 
         // Add vertices for face 3
         x = vertices.at(v3).getX();
         y = vertices.at(v3).getY();
         z = vertices.at(v3).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
     }
     return vertices_data;
 }
 
-std::vector<char> MeshData::getFacesAsBytes()
+std::vector<uint8_t> MeshData::getFacesAsBytes()
 {
-    std::vector<char> face_data;
+    std::vector<uint8_t> face_data;
 
     for(int i = 0; i < faces.size(); i++)
     {
         int v1 = faces.at(i).getV1();
         int v2 = faces.at(i).getV2();
         int v3 = faces.at(i).getV3();
-        face_data.insert(face_data.end(), reinterpret_cast<const char*>(&v1), reinterpret_cast<const char*>(&v1) + sizeof(int));
-        face_data.insert(face_data.end(), reinterpret_cast<const char*>(&v2), reinterpret_cast<const char*>(&v2) + sizeof(int));
-        face_data.insert(face_data.end(), reinterpret_cast<const char*>(&v3), reinterpret_cast<const char*>(&v3) + sizeof(int));
+        face_data.insert(face_data.end(), reinterpret_cast<const uint8_t*>(&v1), reinterpret_cast<const uint8_t*>(&v1) + sizeof(int));
+        face_data.insert(face_data.end(), reinterpret_cast<const uint8_t*>(&v2), reinterpret_cast<const uint8_t*>(&v2) + sizeof(int));
+        face_data.insert(face_data.end(), reinterpret_cast<const uint8_t*>(&v3), reinterpret_cast<const uint8_t*>(&v3) + sizeof(int));
     }
     return face_data;
 }
@@ -132,10 +132,10 @@ void MeshData::toXmlNode(pugi::xml_node& node)
     }
 }
 
-void MeshData::setVerticesFromBytes(const std::vector<char> &data)
+void MeshData::setVerticesFromBytes(const std::vector<uint8_t> &data)
 {
     vertices.clear();
-    const char* bytes = data.data();
+    const uint8_t* bytes = data.data();
     int num_bytes = data.size();
     int num_floats = num_bytes / sizeof(float);
 
@@ -149,10 +149,10 @@ void MeshData::setVerticesFromBytes(const std::vector<char> &data)
     }
 }
 
-void MeshData::setFacesFromBytes(const std::vector<char> &data)
+void MeshData::setFacesFromBytes(const std::vector<uint8_t> &data)
 {
     faces.clear();
-    const char* bytes = data.data();
+    const uint8_t* bytes = data.data();
     int num_bytes = data.size();
     int num_ints = num_bytes / sizeof(int);
 

--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -43,25 +43,25 @@ void MeshData::clear()
     this->vertices.clear();
 }
 
-PyObject* MeshData::getVerticesAsBytes()
+std::vector<char> MeshData::getVerticesAsBytes()
 {
-    std::string vertices_data;
+    std::vector<char> vertices_data;
 
     for(int i = 0; i < vertices.size(); i++)
     {
         float x = vertices.at(i).getX();
         float y = vertices.at(i).getY();
         float z = vertices.at(i).getZ();
-        vertices_data.append(reinterpret_cast<const char*>(&x), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&y), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&z), sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
     }
-    return PyBytes_FromStringAndSize(vertices_data.c_str(), vertices_data.size());
+    return vertices_data;
 }
 
-PyObject* MeshData::getFlatVerticesAsBytes()
+std::vector<char> MeshData::getFlatVerticesAsBytes()
 {
-    std::string vertices_data;
+    std::vector<char> vertices_data;
     for(int i = 0; i < faces.size(); i++)
     {
         int v1 = faces.at(i).getV1();
@@ -72,43 +72,43 @@ PyObject* MeshData::getFlatVerticesAsBytes()
         float x = vertices.at(v1).getX();
         float y = vertices.at(v1).getY();
         float z = vertices.at(v1).getZ();
-        vertices_data.append(reinterpret_cast<const char*>(&x), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&y), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&z), sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
 
         // Add vertices for face 2
         x = vertices.at(v2).getX();
         y = vertices.at(v2).getY();
         z = vertices.at(v2).getZ();
-        vertices_data.append(reinterpret_cast<const char*>(&x), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&y), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&z), sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
 
         // Add vertices for face 3
         x = vertices.at(v3).getX();
         y = vertices.at(v3).getY();
         z = vertices.at(v3).getZ();
-        vertices_data.append(reinterpret_cast<const char*>(&x), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&y), sizeof(float));
-        vertices_data.append(reinterpret_cast<const char*>(&z), sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&x), reinterpret_cast<const char*>(&x) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&y), reinterpret_cast<const char*>(&y) + sizeof(float));
+        vertices_data.insert(vertices_data.end(), reinterpret_cast<const char*>(&z), reinterpret_cast<const char*>(&z) + sizeof(float));
     }
-    return PyBytes_FromStringAndSize(vertices_data.c_str(), vertices_data.size());
+    return vertices_data;
 }
 
-PyObject* MeshData::getFacesAsBytes()
+std::vector<char> MeshData::getFacesAsBytes()
 {
-    std::string face_data;
+    std::vector<char> face_data;
 
     for(int i = 0; i < faces.size(); i++)
     {
         int v1 = faces.at(i).getV1();
         int v2 = faces.at(i).getV2();
         int v3 = faces.at(i).getV3();
-        face_data.append(reinterpret_cast<const char*>(&v1), sizeof(int));
-        face_data.append(reinterpret_cast<const char*>(&v2), sizeof(int));
-        face_data.append(reinterpret_cast<const char*>(&v3), sizeof(int));
+        face_data.insert(face_data.end(), reinterpret_cast<const char*>(&v1), reinterpret_cast<const char*>(&v1) + sizeof(int));
+        face_data.insert(face_data.end(), reinterpret_cast<const char*>(&v2), reinterpret_cast<const char*>(&v2) + sizeof(int));
+        face_data.insert(face_data.end(), reinterpret_cast<const char*>(&v3), reinterpret_cast<const char*>(&v3) + sizeof(int));
     }
-    return PyBytes_FromStringAndSize(face_data.c_str(), face_data.size());
+    return face_data;
 }
 
 void MeshData::toXmlNode(pugi::xml_node& node)
@@ -132,20 +132,15 @@ void MeshData::toXmlNode(pugi::xml_node& node)
     }
 }
 
-void MeshData::setVerticesFromBytes(PyObject* py_bytes)
+void MeshData::setVerticesFromBytes(const std::vector<char> &data)
 {
-    if(py_bytes == nullptr)
-    {
-        return;
-    }
-
     vertices.clear();
-    char* bytes = PyBytes_AsString(py_bytes);
-    int num_bytes = PyBytes_Size(py_bytes);
+    const char* bytes = data.data();
+    int num_bytes = data.size();
     int num_floats = num_bytes / sizeof(float);
 
     //Interpret byte array as array of floats.
-    float* float_array = reinterpret_cast<float*>(bytes);
+    const float* float_array = reinterpret_cast<const float*>(bytes);
 
     for(int i = 0; i < num_floats; i +=3)
     {
@@ -154,20 +149,15 @@ void MeshData::setVerticesFromBytes(PyObject* py_bytes)
     }
 }
 
-void MeshData::setFacesFromBytes(PyObject* py_bytes)
+void MeshData::setFacesFromBytes(const std::vector<char> &data)
 {
-    if(py_bytes == nullptr)
-    {
-        return; 
-    }
-
     faces.clear();
-    char* bytes = PyBytes_AsString(py_bytes);
-    int num_bytes = PyBytes_Size(py_bytes);
+    const char* bytes = data.data();
+    int num_bytes = data.size();
     int num_ints = num_bytes / sizeof(int);
 
     //Interpret byte array as array of ints.
-    int* int_array = reinterpret_cast<int*>(bytes);
+    const int* int_array = reinterpret_cast<const int*>(bytes);
 
     for(int i = 0; i < num_ints; i +=3)
     {

--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -142,7 +142,7 @@ void MeshData::setVerticesFromBytes(const std::vector<char> &data)
     //Interpret byte array as array of floats.
     const float* float_array = reinterpret_cast<const float*>(bytes);
 
-    for(int i = 0; i < num_floats; i +=3)
+    for(int i = 0; i + 2 < num_floats; i +=3)
     {
         Vertex temp_vertex = Vertex(float_array[i], float_array[i + 1], float_array[i + 2]);
         this->vertices.push_back(temp_vertex);
@@ -159,7 +159,7 @@ void MeshData::setFacesFromBytes(const std::vector<char> &data)
     //Interpret byte array as array of ints.
     const int* int_array = reinterpret_cast<const int*>(bytes);
 
-    for(int i = 0; i < num_ints; i +=3)
+    for(int i = 0; i + 2 < num_ints; i +=3)
     {
         Face temp_face = Face(int_array[i], int_array[i + 1], int_array[i + 2]);
         this->faces.push_back(temp_face);

--- a/src/MeshData.h
+++ b/src/MeshData.h
@@ -79,14 +79,14 @@ namespace Savitar
          *
          * For every vertex it's assumed that there are 12 bytes (3 floats * 4).
          */
-        void setVerticesFromBytes(const std::vector<uint8_t> &data);
+        void setVerticesFromBytes(const std::vector<uint8_t>& data);
 
         /**
          * Set the faces of the meshdata by bytearray (as set from python)
          *
          * For every face it's assumed that there are 12 bytes (3 int * 4).
          */
-        void setFacesFromBytes(const std::vector<uint8_t> &data);
+        void setFacesFromBytes(const std::vector<uint8_t>& data);
 
         std::vector<Vertex> getVertices();
 

--- a/src/MeshData.h
+++ b/src/MeshData.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <cstdint>
 
+#include "Types.h"
 #include "Vertex.h"
 #include "Face.h"
 
@@ -59,34 +60,34 @@ namespace Savitar
          *
          * If there for example is a single vertex, it will return a byte array containing 3 floats (so 3 * 4 bytes)
          */
-        std::vector<uint8_t> getVerticesAsBytes();
+        bytearray getVerticesAsBytes();
 
         /**
          * Return the faces as flattend bytes.
          *
          * If there for example is a single face, it will return a byte array containing 3 ints (so 3 * 4 bytes)
          */
-        std::vector<uint8_t> getFacesAsBytes();
+        bytearray getFacesAsBytes();
 
         /**
          * Instead of getting all unique vertices, this function returns a bytearray with 3 vertices per face.
          * This is usefull if you want to mimic the data type of STL files.
          */
-        std::vector<uint8_t> getFlatVerticesAsBytes();
+        bytearray getFlatVerticesAsBytes();
 
         /**
          * Set the vertices of the meshdata by bytearray (as set from python)
          *
          * For every vertex it's assumed that there are 12 bytes (3 floats * 4).
          */
-        void setVerticesFromBytes(const std::vector<uint8_t>& data);
+        void setVerticesFromBytes(const bytearray& data);
 
         /**
          * Set the faces of the meshdata by bytearray (as set from python)
          *
          * For every face it's assumed that there are 12 bytes (3 int * 4).
          */
-        void setFacesFromBytes(const std::vector<uint8_t>& data);
+        void setFacesFromBytes(const bytearray& data);
 
         std::vector<Vertex> getVertices();
 

--- a/src/MeshData.h
+++ b/src/MeshData.h
@@ -21,7 +21,6 @@
 #include "SavitarExport.h"
 #include <vector>
 #include <string>
-#include <Python.h> // For PyObject
 
 #include "Vertex.h"
 #include "Face.h"
@@ -59,34 +58,34 @@ namespace Savitar
          *
          * If there for example is a single vertex, it will return a byte array containing 3 floats (so 3 * 4 bytes)
          */
-        PyObject* getVerticesAsBytes();
+        std::vector<char> getVerticesAsBytes();
 
         /**
          * Return the faces as flattend bytes.
          *
          * If there for example is a single face, it will return a byte array containing 3 ints (so 3 * 4 bytes)
          */
-        PyObject* getFacesAsBytes();
+        std::vector<char> getFacesAsBytes();
 
         /**
          * Instead of getting all unique vertices, this function returns a bytearray with 3 vertices per face.
          * This is usefull if you want to mimic the data type of STL files.
          */
-        PyObject* getFlatVerticesAsBytes();
+        std::vector<char> getFlatVerticesAsBytes();
 
         /**
          * Set the vertices of the meshdata by bytearray (as set from python)
          *
          * For every vertex it's assumed that there are 12 bytes (3 floats * 4).
          */
-        void setVerticesFromBytes(PyObject* py_bytes);
+        void setVerticesFromBytes(const std::vector<char> &data);
 
         /**
          * Set the faces of the meshdata by bytearray (as set from python)
          *
          * For every face it's assumed that there are 12 bytes (3 int * 4).
          */
-        void setFacesFromBytes(PyObject* py_bytes);
+        void setFacesFromBytes(const std::vector<char> &data);
 
         std::vector<Vertex> getVertices();
 

--- a/src/MeshData.h
+++ b/src/MeshData.h
@@ -21,6 +21,7 @@
 #include "SavitarExport.h"
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #include "Vertex.h"
 #include "Face.h"
@@ -58,34 +59,34 @@ namespace Savitar
          *
          * If there for example is a single vertex, it will return a byte array containing 3 floats (so 3 * 4 bytes)
          */
-        std::vector<char> getVerticesAsBytes();
+        std::vector<uint8_t> getVerticesAsBytes();
 
         /**
          * Return the faces as flattend bytes.
          *
          * If there for example is a single face, it will return a byte array containing 3 ints (so 3 * 4 bytes)
          */
-        std::vector<char> getFacesAsBytes();
+        std::vector<uint8_t> getFacesAsBytes();
 
         /**
          * Instead of getting all unique vertices, this function returns a bytearray with 3 vertices per face.
          * This is usefull if you want to mimic the data type of STL files.
          */
-        std::vector<char> getFlatVerticesAsBytes();
+        std::vector<uint8_t> getFlatVerticesAsBytes();
 
         /**
          * Set the vertices of the meshdata by bytearray (as set from python)
          *
          * For every vertex it's assumed that there are 12 bytes (3 floats * 4).
          */
-        void setVerticesFromBytes(const std::vector<char> &data);
+        void setVerticesFromBytes(const std::vector<uint8_t> &data);
 
         /**
          * Set the faces of the meshdata by bytearray (as set from python)
          *
          * For every face it's assumed that there are 12 bytes (3 int * 4).
          */
-        void setFacesFromBytes(const std::vector<char> &data);
+        void setFacesFromBytes(const std::vector<uint8_t> &data);
 
         std::vector<Vertex> getVertices();
 

--- a/src/SavitarExport.h
+++ b/src/SavitarExport.h
@@ -1,10 +1,6 @@
 #ifndef SAVITAR_EXPORT_H
 #define SAVITAR_EXPORT_H
 
-// This is included here as a workaround for Python's library adding declarations that
-// conflict with C++'s standard library.
-#include <Python.h>
-
 #if _WIN32
     #ifdef MAKE_SAVITAR_LIB
         #define SAVITAR_EXPORT __declspec(dllexport)

--- a/src/Types.h
+++ b/src/Types.h
@@ -1,5 +1,34 @@
+/*
+ * This file is part of libSavitar
+ *
+ * Copyright (C) 2017 Ultimaker b.v. <j.vankessel@ultimaker.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SAVITAR_TYPES_H
+#define SAVITAR_TYPES_H
+
+#include <vector>
+#include <cstdint>
+
 namespace Savitar
 {
     // Convenience typedef so uint can be used.
     typedef unsigned int uint;
+
+    // Dynamic array of bytes, defined here to increase code readability.
+    typedef std::vector<uint8_t> bytearray;
 }
+
+#endif


### PR DESCRIPTION
This patch changes the method signatures in class MeshData  so they rely on C++ types exclusively.

It also adds type conversions for C++ byte buffers (`std::vector<char>`) and adds SavitarExport.h to the list of installable header files.

This makes libSavitar independent of Python and allows building regular C++ programs against it.

Adresses #2.