### PR TITLE
Ensure that pugixml uses the same C++ standard library as Savitar does.

### DIFF
--- a/pugixml/CMakeLists.txt
+++ b/pugixml/CMakeLists.txt
@@ -44,6 +44,10 @@ endif()
 
 set_target_properties(pugixml PROPERTIES COMPILE_FLAGS -fPIC)
 
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 # Enable C++11 long long for compilers that are capable of it
 if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1 AND ";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_long_long_type;")
         target_compile_features(pugixml PUBLIC cxx_long_long_type)


### PR DESCRIPTION
Without this I was getting link errors as Savitar and pugixml were being compiled using
different standard libraries.