### PR TITLE
Actually use xml-namespaces to resolve cura-ns.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ write_basic_package_version_file(${CMAKE_BINARY_DIR}/SavitarConfigVersion.cmake 
 set(savitar_TEST
     ThreeMFParserTest
     MeshDataTest
+    NamespaceTest
 )
 
 # Compiling the test environment.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 set(savitar_SRCS
+    src/Namespace.cpp
     src/ThreeMFParser.cpp
     src/SceneNode.cpp
     src/Scene.cpp
@@ -55,6 +56,7 @@ set(savitar_SRCS
 )
 
 set(savitar_HDRS
+    src/Namespace.h
     src/ThreeMFParser.h
     src/Types.h
     src/SceneNode.h

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,5 +19,5 @@ cmake3 \
     -DCMAKE_PREFIX_PATH="${CURA_BUILD_ENV_PATH}" \
     -DBUILD_TESTS=ON \
     ..
-make
+VEBOSE=1 make
 ctest3 --output-on-failure -T Test

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -18,6 +18,7 @@ cmake3 \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_PREFIX_PATH="${CURA_BUILD_ENV_PATH}" \
     -DBUILD_TESTS=ON \
+    -DBUILD_STATIC=ON \
     ..
 VERBOSE=1 make
 ctest3 --output-on-failure -T Test

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,5 +19,5 @@ cmake3 \
     -DCMAKE_PREFIX_PATH="${CURA_BUILD_ENV_PATH}" \
     -DBUILD_TESTS=ON \
     ..
-VEBOSE=1 make
+VERBOSE=1 make
 ctest3 --output-on-failure -T Test

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -20,5 +20,5 @@ cmake3 \
     -DBUILD_TESTS=ON \
     -DBUILD_STATIC=ON \
     ..
-VERBOSE=1 make
+make
 ctest3 --output-on-failure -T Test

--- a/src/Namespace.cpp
+++ b/src/Namespace.cpp
@@ -1,0 +1,46 @@
+#include "Namespace.h"
+
+#include "../pugixml/src/pugixml.hpp"
+
+namespace xml_namespace
+{
+    std::string getCuraUri() { return std::string("http://software.ultimaker.com/xml/cura/3mf/2015/10"); }
+    std::string getDefaultUri() { return std::string("http://schemas.microsoft.com/3dmanufacturing/core/2015/02"); }
+
+    void appendNamespaceAttributes(xmlns_map_t& map, const pugi::xml_node& xml_node)
+    {
+        for (const pugi::xml_attribute& attribute : xml_node.attributes())
+        {
+            const std::string name = attribute.name();
+            const std::string name_start = name.substr(0, name.size() >= 5 ? 5 : std::string::npos);
+            if (name_start.compare("xmlns") != 0)
+            {
+                continue;
+            }
+
+            const std::string namespace_name = name.size() <= 5 ? "" : name.substr(6);
+            const std::string namespace_glob = attribute.value();
+            if (map.count(namespace_glob) < 1)
+            {
+                map[namespace_glob] = std::set<std::string>();
+            }
+            map[namespace_glob].insert(namespace_name);
+        }
+    }
+
+    xmlns_map_t getAncestralNamespaces(const pugi::xml_node& xml_node)
+    {
+        xmlns_map_t result;
+        for (pugi::xml_node current_node = xml_node; current_node; current_node = current_node.parent())
+        {
+            appendNamespaceAttributes(result, current_node);
+        }
+        return result;
+    }
+
+    std::set<std::string> getNamesFor(const xmlns_map_t& map, const std::string& uri)
+    {
+        return (map.count(uri) > 0) ? map.at(uri) : std::set<std::string>();
+    }
+
+} //namespace xml_namespace

--- a/src/Namespace.h
+++ b/src/Namespace.h
@@ -1,6 +1,10 @@
 //Copyright (c) 2020 Ultimaker B.V.
 //libSavitar is released under the terms of the AGPLv3 or higher.
 
+#ifndef NAMESPACE_H
+#define NAMESPACE_H
+
+#include "SavitarExport.h"
 #include <map>
 #include <set>
 #include <string>
@@ -18,6 +22,8 @@ namespace xml_namespace
     std::string getCuraUri();
     std::string getDefaultUri();
 
-    xmlns_map_t getAncestralNamespaces(const pugi::xml_node& xml_node);
-    std::set<std::string> getNamesFor(const xmlns_map_t& map, const std::string& uri);
+    xmlns_map_t SAVITAR_EXPORT getAncestralNamespaces(const pugi::xml_node& xml_node);
+    std::set<std::string> SAVITAR_EXPORT getNamesFor(const xmlns_map_t& map, const std::string& uri);
 } //namespace xml_namespace
+
+#endif

--- a/src/Namespace.h
+++ b/src/Namespace.h
@@ -1,3 +1,6 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//libSavitar is released under the terms of the AGPLv3 or higher.
+
 #include <map>
 #include <set>
 #include <string>

--- a/src/Namespace.h
+++ b/src/Namespace.h
@@ -1,0 +1,20 @@
+#include <map>
+#include <set>
+#include <string>
+
+// Forward declaration
+namespace pugi
+{
+    class xml_node;
+}
+
+namespace xml_namespace
+{
+    typedef std::map<std::string, std::set<std::string>> xmlns_map_t;
+
+    std::string getCuraUri();
+    std::string getDefaultUri();
+
+    xmlns_map_t getAncestralNamespaces(const pugi::xml_node& xml_node);
+    std::set<std::string> getNamesFor(const xmlns_map_t& map, const std::string& uri);
+} //namespace xml_namespace

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "SceneNode.h"
+#include "Namespace.h"
 #include "../pugixml/src/pugixml.hpp"
 #include <iostream>
 using namespace Savitar;
@@ -95,11 +96,14 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
     {
         for (pugi::xml_node setting = metadatagroup_node.child("metadata"); setting; setting = setting.next_sibling("metadata"))
         {
+            const xml_namespace::xmlns_map_t namespaces = xml_namespace::getAncestralNamespaces(setting);
+            const std::set<std::string> cura_equivalent_namespaces = xml_namespace::getNamesFor(namespaces, xml_namespace::getCuraUri());
+
             std::string key = setting.attribute("name").as_string();
             const size_t pos = key.find_first_of(':');
 
-            // Other namespaces can be in the metadata, not just Cura's, don't load those:
-            if (key.substr(0, pos).compare("cura") != 0)
+            // Only accept namespaces cura and implied 'default':
+            if (pos != std::string::npos && cura_equivalent_namespaces.count(key.substr(0, pos)) < 1)
             {
                 continue;
             }

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -96,8 +96,11 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
     {
         for (pugi::xml_node setting = metadatagroup_node.child("metadata"); setting; setting = setting.next_sibling("metadata"))
         {
+            // NOTE: In theory this could be slow, since we look up the entire ancestry tree for each setting.
+            //       In practice it's expected to be negligible compared to the parsing of the mesh.
             const xml_namespace::xmlns_map_t namespaces = xml_namespace::getAncestralNamespaces(setting);
-            const std::set<std::string> cura_equivalent_namespaces = xml_namespace::getNamesFor(namespaces, xml_namespace::getCuraUri());
+            std::set<std::string> cura_equivalent_namespaces = xml_namespace::getNamesFor(namespaces, xml_namespace::getCuraUri());
+            cura_equivalent_namespaces.insert("cura"); // <- Just to be sure: If there was ever a version out that uses 'cura' without the specification of the xmlns-id.
 
             std::string key = setting.attribute("name").as_string();
             const size_t pos = key.find_first_of(':');

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "ThreeMFParser.h"
+#include "Namespace.h"
 #include "Scene.h"
 #include <iostream>
 #include <sstream>
@@ -55,8 +56,8 @@ std::string ThreeMFParser::sceneToString(Scene scene)
     pugi::xml_node build_node = model_node.append_child("build");
 
     model_node.append_attribute("unit") = scene.getUnit().c_str();
-    model_node.append_attribute("xmlns") = "http://schemas.microsoft.com/3dmanufacturing/core/2015/02";
-    model_node.append_attribute("xmlns:cura") = "http://software.ultimaker.com/xml/cura/3mf/2015/10";
+    model_node.append_attribute("xmlns") = xml_namespace::getCuraUri().c_str();
+    model_node.append_attribute("xmlns:cura") = xml_namespace::getDefaultUri().c_str();
     model_node.append_attribute("xml:lang") ="en-US";
 
     for(int i = 0; i < scene.getAllSceneNodes().size(); i++)

--- a/tests/NamespaceTest.cpp
+++ b/tests/NamespaceTest.cpp
@@ -107,8 +107,9 @@ namespace xml_namespace
     {
         ASSERT_TRUE(main_xml_node);
         pugi::xml_node node = main_xml_node.child("multideep").child("sub").child("subber").child("subbest");
-        ASSERT_EQ(getNamesFor(node, "_w_").count("w"), 1);
-        ASSERT_EQ(getNamesFor(node, "_p_").size(), 0);
+        xml_namespace::xmlns_map_t map = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(xml_namespace::getNamesFor(map, "_w_").count("w"), 1);
+        ASSERT_EQ(xml_namespace::getNamesFor(map, "_p_").size(), 0);
     }
 
 } // namespace xml_namespace

--- a/tests/NamespaceTest.cpp
+++ b/tests/NamespaceTest.cpp
@@ -14,6 +14,7 @@ namespace xml_namespace
     class NamespaceTest : public testing::Test
     {
     public:
+        pugi::xml_document document;
         pugi::xml_node main_xml_node;
 
         void SetUp()
@@ -23,7 +24,6 @@ namespace xml_namespace
             {
                 const std::string xml_string(std::istreambuf_iterator<char>{test_model_file}, {});
 
-                pugi::xml_document document;
                 pugi::xml_parse_result result = document.load_string(xml_string.c_str());
                 main_xml_node = document.child("main");
             }

--- a/tests/NamespaceTest.cpp
+++ b/tests/NamespaceTest.cpp
@@ -9,8 +9,8 @@
 #include <string>
 #include "../pugixml/src/pugixml.hpp"
 
-//namespace xml_namespace
-//{
+namespace xml_namespace
+{
     class NamespaceTest : public testing::Test
     {
     public:
@@ -112,4 +112,4 @@
         ASSERT_EQ(xml_namespace::getNamesFor(map, "_p_").size(), 0);
     }
 
-//} // namespace xml_namespace
+} // namespace xml_namespace

--- a/tests/NamespaceTest.cpp
+++ b/tests/NamespaceTest.cpp
@@ -9,8 +9,8 @@
 #include <string>
 #include "../pugixml/src/pugixml.hpp"
 
-namespace xml_namespace
-{
+//namespace xml_namespace
+//{
     class NamespaceTest : public testing::Test
     {
     public:
@@ -112,4 +112,4 @@ namespace xml_namespace
         ASSERT_EQ(xml_namespace::getNamesFor(map, "_p_").size(), 0);
     }
 
-} // namespace xml_namespace
+//} // namespace xml_namespace

--- a/tests/NamespaceTest.cpp
+++ b/tests/NamespaceTest.cpp
@@ -1,0 +1,114 @@
+//Copyright (c) 2020 Ultimaker B.V.
+//libSavitar is released under the terms of the AGPLv3 or higher.
+
+#include "../src/Namespace.h"
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <string>
+#include "../pugixml/src/pugixml.hpp"
+
+namespace xml_namespace
+{
+    class NamespaceTest : public testing::TestWithParam<InfillTestParameters>
+    {
+    public:
+        pugi::xml_node main_xml_node;
+
+        void SetUp()
+        {
+            xml_string = "";
+            std::ifstream test_model_file("../tests/namespaces.xml");
+            if (test_model_file.is_open())
+            {
+                const std::string xml_string(std::istreambuf_iterator<char>{test_model_file}, {});
+
+                pugi::xml_document document;
+                pugi::xml_parse_result result = document.load_string(xml_string.c_str());
+                main_xml_node = document.child("main");
+            }
+        }
+    };
+
+    TEST_P(NamespaceTest, getAncestralNamespaces)
+    {
+        ASSERT_TRUE(main_xml_node);
+     
+        NamespaceTestParameters params = GetParam();
+
+        pugi::xml_node node;
+        xml_namespace::xmlns_map_t result;
+        
+        node = main_xml_node.child("simple");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 2); // <-- including default namespace
+        ASSERT_EQ(result["_a_"].size(), 1);
+        ASSERT_EQ(result["_a_"].count("a"), 1);
+
+        node = main_xml_node.child("multiple");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result["_a_"].count("a"), 1);
+        ASSERT_EQ(result["_b_"].count("b"), 1);
+        ASSERT_EQ(result["_c_"].count("c"), 1);
+
+        node = main_xml_node.child("overwrite"); // _before_ overwrite
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 2);
+        ASSERT_EQ(result["_b_"].size(), 1);
+        ASSERT_EQ(result["_b_"].count("b"), 1);
+
+        node = main_xml_node.child("overwrite").child("sub"); // _after_ overwrite
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 2);
+        ASSERT_EQ(result.count("_b_"), 0);
+        ASSERT_EQ(result["_c_"].size(), 1);
+        ASSERT_EQ(result["_c_"].count("b"), 1);
+
+        node = main_xml_node.child("combine").child("sub");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 2);
+        ASSERT_EQ(result["_s_"].size(), 2);
+        ASSERT_EQ(result["_s_"].count("s"), 1);
+        ASSERT_EQ(result["_s_"].count("n"), 1);
+
+        node = main_xml_node.child("deep").child("sub");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 3);
+        ASSERT_EQ(result.count("_w_"), 0);
+        ASSERT_EQ(result.count("_x_"), 1);
+
+        node = main_xml_node.child("deep").child("sub").child("subber").child("subbest");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 6);
+        ASSERT_EQ(result.count("_w_"), 1);
+        ASSERT_EQ(result.count("_x_"), 1);
+
+        node = main_xml_node.child("multideep").child("sub").child("subber").child("subbest");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 6);
+        ASSERT_EQ(result.count("_w_"), 1);
+        ASSERT_EQ(result.count("_x_"), 1);
+
+        node = main_xml_node.child("multideep").child("subber").child("subbest");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 5);
+        ASSERT_EQ(result.count("_w_"), 0);
+        ASSERT_EQ(result.count("_e_"), 1);
+        ASSERT_EQ(result.count("_q_"), 1);
+        ASSERT_EQ(result.count("_r_"), 1);
+        
+        node = main_xml_node.child("multideep").child("subbest");
+        result = xml_namespace::getAncestralNamespaces(node);
+        ASSERT_EQ(result.size(), 3);
+        ASSERT_EQ(result.count("_e_"), 0);
+        ASSERT_EQ(result.count("_q_"), 1);
+    }
+
+    // std::set<std::string> getNamesFor(const xmlns_map_t& map, const std::string& uri);
+    TEST_F(NamesapceTest, getNamesFor)
+    {
+        ASSERT_TRUE(main_xml_node);
+    }
+
+} // namespace xml_namespace

--- a/tests/NamespaceTest.cpp
+++ b/tests/NamespaceTest.cpp
@@ -11,14 +11,13 @@
 
 namespace xml_namespace
 {
-    class NamespaceTest : public testing::TestWithParam<InfillTestParameters>
+    class NamespaceTest : public testing::Test
     {
     public:
         pugi::xml_node main_xml_node;
 
         void SetUp()
         {
-            xml_string = "";
             std::ifstream test_model_file("../tests/namespaces.xml");
             if (test_model_file.is_open())
             {
@@ -31,15 +30,13 @@ namespace xml_namespace
         }
     };
 
-    TEST_P(NamespaceTest, getAncestralNamespaces)
+    TEST_F(NamespaceTest, getAncestralNamespaces)
     {
         ASSERT_TRUE(main_xml_node);
-     
-        NamespaceTestParameters params = GetParam();
 
         pugi::xml_node node;
         xml_namespace::xmlns_map_t result;
-        
+
         node = main_xml_node.child("simple");
         result = xml_namespace::getAncestralNamespaces(node);
         ASSERT_EQ(result.size(), 2); // <-- including default namespace
@@ -97,7 +94,7 @@ namespace xml_namespace
         ASSERT_EQ(result.count("_e_"), 1);
         ASSERT_EQ(result.count("_q_"), 1);
         ASSERT_EQ(result.count("_r_"), 1);
-        
+
         node = main_xml_node.child("multideep").child("subbest");
         result = xml_namespace::getAncestralNamespaces(node);
         ASSERT_EQ(result.size(), 3);
@@ -106,9 +103,12 @@ namespace xml_namespace
     }
 
     // std::set<std::string> getNamesFor(const xmlns_map_t& map, const std::string& uri);
-    TEST_F(NamesapceTest, getNamesFor)
+    TEST_F(NamespaceTest, getNamesFor)
     {
         ASSERT_TRUE(main_xml_node);
+        pugi::xml_node node = main_xml_node.child("multideep").child("sub").child("subber").child("subbest");
+        ASSERT_EQ(getNamesFor(node, "_w_").count("w"), 1);
+        ASSERT_EQ(getNamesFor(node, "_p_").size(), 0);
     }
 
 } // namespace xml_namespace

--- a/tests/ThreeMFParserTest.cpp
+++ b/tests/ThreeMFParserTest.cpp
@@ -5,6 +5,7 @@
 #include "../src/SceneNode.h"
 #include "../src/ThreeMFParser.h"
 
+#include <array>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iostream>

--- a/tests/namespaces.xml
+++ b/tests/namespaces.xml
@@ -3,7 +3,7 @@
 
     <simple xmlns:a="_a_"/>
   
-    <multiple xmlns:a="_a_" xmlns:b="_c_" xmlns:c="_c_"/>
+    <multiple xmlns:a="_a_" xmlns:b="_b_" xmlns:c="_c_"/>
   
     <overwrite xmlns:b="_b_">
       <sub xmlns:b="_c_"/>

--- a/tests/namespaces.xml
+++ b/tests/namespaces.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<main unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" xml:lang="en-US">
+
+    <simple xmlns:a="_a_"/>
+  
+    <multiple xmlns:a="_a_" xmlns:b="_c_" xmlns:c="_c_"/>
+  
+    <overwrite xmlns:b="_b_">
+      <sub xmlns:b="_c_"/>
+    </overwrite>
+
+    <combine xmlns:s="_s_">
+      <sub  xmlns:n="_s_"/>
+    </combine>
+  
+    <deep xmlns:x="_x_">
+      <sub xmlns:y="_y_">
+        <subber xmlns:z="_z_" xmlns:e="_e_">
+          <subbest xmlns:w="_w_">
+          </subbest>
+        </subber>
+      </sub>
+    </deep>
+
+  <multideep xmlns:x="_x_">
+    <sub xmlns:y="_y_">
+      <subber xmlns:z="_z_"  xmlns:e="_e_">
+        <subbest xmlns:w="_w_">
+        </subbest>
+      </subber>
+    </sub>
+    <subber xmlns:z="_q_"  xmlns:e="_e_">
+      <subbest xmlns:w="_r_">
+      </subbest>
+    </subber>
+    <subbest xmlns:w="_q_">
+    </subbest>
+  </multideep>
+  
+</main>


### PR DESCRIPTION
(Hopefully) fixes: https://github.com/Ultimaker/Cura/issues/6922

The downside of the current approach it that it retrieves the entire namespace scope from the ancestors for each altered setting. (Not exactly what you'd call optimised.) It's expected that this will be negligible compared to parsing the actual mesh in practice though, and will do fine for now.

CURA-7120