### PR TITLE
Add SceneNode name as <object> attribute

### DIFF
--- a/python/SceneNode.sip
+++ b/python/SceneNode.sip
@@ -32,6 +32,9 @@ public:
     std::string getTransformation();
     void setTransformation(std::string);
 
+    std::string getName();
+    void setName(std::string name);
+
     std::map<std::string, std::string> getSettings();
     void setSetting(std::string key, std::string value);
 

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -71,6 +71,7 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
 {
     settings.clear();
     id = xml_node.attribute("id").as_string();
+    name = xml_node.attribute("name").as_string();
 
     if(xml_node.child("mesh"))
     {
@@ -126,6 +127,16 @@ std::string SceneNode::getId()
 void SceneNode::setId(std::string id)
 {
     this->id = id;
+}
+
+std::string SceneNode::getName()
+{
+    return this->name;
+}
+
+void SceneNode::setName(std::string name)
+{
+    this->name = name;
 }
 
 std::map< std::string, std::string > SceneNode::getSettings()

--- a/src/SceneNode.h
+++ b/src/SceneNode.h
@@ -62,6 +62,13 @@ namespace Savitar
         void setId(std::string id);
 
         /**
+         * Get the (non-unique) display name of the node.
+         */
+        std::string getName();
+
+        void setName(std::string name);
+
+        /**
          * Get the (per-object) settings attached to this SceneNode.
          * Note that this is part of the Cura Extension and not 3mf Core.
          */
@@ -75,6 +82,7 @@ namespace Savitar
         MeshData mesh_data;
         std::map<std::string, std::string> settings;
         std::string id;
+        std::string name;
     };
 }
 

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -71,6 +71,10 @@ std::string ThreeMFParser::sceneToString(Scene scene)
         // Create item
         pugi::xml_node object = resources_node.append_child("object");
         object.append_attribute("id") = scene_node->getId().c_str();
+        if(!scene_node->getName().empty())
+        {
+            object.append_attribute("name") = scene_node->getName().c_str();
+        }
         object.append_attribute("type") = "model";
 
         if(scene_node->getMeshData().getVertices().size() != 0)

--- a/tests/ThreeMFParserTest.cpp
+++ b/tests/ThreeMFParserTest.cpp
@@ -100,6 +100,8 @@ TEST_F(ThreeMFParserTest, parse)
     EXPECT_NE(settings.find("infill_pattern"), settings.end());
     EXPECT_EQ(settings["infill_pattern"].compare("concentric"), 0);
 
+    EXPECT_EQ(nodes[0]->getName().compare("test_object"), 0);
+    EXPECT_EQ(nodes[1]->getName().compare(""), 0);
     EXPECT_EQ(nodes[1]->getId().compare("2"), 0);
     EXPECT_FALSE(nodes[1]->getTransformation().empty());
 }

--- a/tests/test_model.xml
+++ b/tests/test_model.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" xml:lang="en-US">
     <resources>
-        <object id="1" type="model">
+        <object id="1" name="test_object" type="model">
             <!-- normal mesh with 3 unique vert-refs per triangle -->
             <mesh>
                 <vertices>


### PR DESCRIPTION
This PR supports adding and parsing SceneNode (model) names as attributes of <object> nodes, per the 3MF spec: https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md#attributes-3
These model names are not enforced to be unique, and should be used for (human) readability (eg the model list in Cura).

TODO:
* ~write/adapt tests~
* ~add support for this in Cura so Cura remembers model names when saving projects in ThreeMFReader and ThreeMFWriter~

See the companion Cura patch here: https://github.com/Ultimaker/Cura/pull/7310