### PR TITLE
Allow object id to be read in python

### DIFF
--- a/python/SceneNode.sip
+++ b/python/SceneNode.sip
@@ -31,9 +31,12 @@ public:
 
     std::string getTransformation();
     void setTransformation(std::string);
-
+    
     std::string getName();
     void setName(std::string name);
+
+    std::string getId();
+    void setId(std::string id);
 
     std::map<std::string, std::string> getSettings();
     void setSetting(std::string key, std::string value);


### PR DESCRIPTION
Expose the setId and getId of the SceneNode so that they can be used in Python.

CURA-7333