### PR TITLE
Require Python 3.5

### DIFF
--- a/cmake/FindSIP.cmake
+++ b/cmake/FindSIP.cmake
@@ -26,8 +26,8 @@ endif()
 
 # FIXME: Use the new FindPython3 module rather than these. New in CMake 3.12.
 # However currently that breaks on our CI server, since the CI server finds the built-in Python3.6 and then doesn't find the headers.
-find_package(PythonInterp 3.4 REQUIRED)
-find_package(PythonLibs 3.4 REQUIRED)
+find_package(PythonInterp 3.5 REQUIRED)
+find_package(PythonLibs 3.5 REQUIRED)
 
 # Define variables that are available in FindPython3, so there's no need to branch off in the later part.
 set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})


### PR DESCRIPTION
This has been a requirement for a long time. If the user also has Python 3.4 installed, we don't want to find that one. We want to find 3.5 if it's installed.

Contributes to issue CURA-7259.