### PR TITLE
CURA-7790: Fix crash occuring when the faces have wrong vertex ids

### DIFF
--- a/src/MeshData.cpp
+++ b/src/MeshData.cpp
@@ -97,30 +97,52 @@ bytearray MeshData::getFlatVerticesAsBytes()
         int v1 = faces.at(i).getV1();
         int v2 = faces.at(i).getV2();
         int v3 = faces.at(i).getV3();
+        float x, y, z;
         
         // Add vertices for face 1
-        float x = vertices.at(v1).getX();
-        float y = vertices.at(v1).getY();
-        float z = vertices.at(v1).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
+        if (v1 >= 0 && v1 < vertices.size())
+        {
+            x = vertices.at(v1).getX();
+            y = vertices.at(v1).getY();
+            z = vertices.at(v1).getZ();
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
+        }
+        else
+        {
+            return bytearray();
+        }
 
         // Add vertices for face 2
-        x = vertices.at(v2).getX();
-        y = vertices.at(v2).getY();
-        z = vertices.at(v2).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
+        if (v2 >= 0 && v2 < vertices.size())
+        {
+            x = vertices.at(v2).getX();
+            y = vertices.at(v2).getY();
+            z = vertices.at(v2).getZ();
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
+        }
+        else
+        {
+            return bytearray();
+        }
 
         // Add vertices for face 3
-        x = vertices.at(v3).getX();
-        y = vertices.at(v3).getY();
-        z = vertices.at(v3).getZ();
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
-        vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
+        if (v3 >= 0 && v3 < vertices.size())
+        {
+            x = vertices.at(v3).getX();
+            y = vertices.at(v3).getY();
+            z = vertices.at(v3).getZ();
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&x), reinterpret_cast<const uint8_t*>(&x) + sizeof(float));
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&y), reinterpret_cast<const uint8_t*>(&y) + sizeof(float));
+            vertices_data.insert(vertices_data.end(), reinterpret_cast<const uint8_t*>(&z), reinterpret_cast<const uint8_t*>(&z) + sizeof(float));
+        }
+        else
+        {
+            return bytearray();
+        }
     }
     return vertices_data;
 }


### PR DESCRIPTION
It can happen that the triangles in the object-to-be-loaded refer to vertex id's that do not exist
in the vertices table. This means that either Cura made a mistake in saving these objects or that
the triangles of the objects have been manually changed. In any case, this was causing a crash.

This is now fixed by valdiating whether the vertex id's are within limits. Even if one of them is
not, it means the triangle will not be loaded and we will end up with a possibly non-manifold and
overall wrong object (especially if there are multiple mistakes like that). So, in such cases,
refrain from loading the object by returning an empty bytearray.

CURA-7790