### PR TITLE
Update long deprecated sip type conversion functions

### DIFF
--- a/python/Types.sip
+++ b/python/Types.sip
@@ -94,7 +94,7 @@
         for (int i = 0; i < (int)sipCpp->size(); ++i)
         {
             SceneNode *cpp = new SceneNode(*sipCpp->at(i));
-            PyObject *pobj = sipConvertFromInstance(cpp, sipClass_SceneNode, sipTransferObj);
+            PyObject *pobj = sipConvertFromType(cpp, sipType_SceneNode, sipTransferObj);
 
             // Get the Python wrapper for the Type instance, creating a new
             // one if necessary, and handle any ownership transfer.
@@ -132,7 +132,7 @@
 
         while ((item = PyIter_Next(iterator)))
         {
-            if (!sipCanConvertToInstance(item, sipClass_SceneNode, SIP_NOT_NONE))
+            if (!sipCanConvertToType(item, sipType_SceneNode, SIP_NOT_NONE))
             {
                 PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to SceneNode");
                 *sipIsErr = 1;
@@ -140,14 +140,14 @@
             }
 
             int state;
-            SceneNode* p = reinterpret_cast<SceneNode*>(sipConvertToInstance(item, sipClass_SceneNode, 0, SIP_NOT_NONE, &state, sipIsErr));
+            SceneNode* p = reinterpret_cast<SceneNode*>(sipConvertToType(item, sipType_SceneNode, 0, SIP_NOT_NONE, &state, sipIsErr));
 
             if (!*sipIsErr)
             {
                 result_vector->push_back(p);
             }
 
-            sipReleaseInstance(p, sipClass_SceneNode, state);
+            sipReleaseType(p, sipType_SceneNode, state);
             Py_DECREF(item);
         }
 
@@ -226,7 +226,7 @@ template<TYPE>
         for (int i = 0; i < (int)sipCpp->size(); ++i)
         {
             TYPE *cpp = new TYPE(sipCpp->at(i));
-            PyObject *pobj = sipConvertFromInstance(cpp, sipClass_TYPE, sipTransferObj);
+            PyObject *pobj = sipConvertFromType(cpp, sipType_TYPE, sipTransferObj);
 
             // Get the Python wrapper for the Type instance, creating a new
             // one if necessary, and handle any ownership transfer.
@@ -264,7 +264,7 @@ template<TYPE>
 
         while ((item = PyIter_Next(iterator)))
         {
-            if (!sipCanConvertToInstance(item, sipClass_TYPE, SIP_NOT_NONE))
+            if (!sipCanConvertToType(item, sipType_TYPE, SIP_NOT_NONE))
             {
                 PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
                 *sipIsErr = 1;
@@ -272,14 +272,14 @@ template<TYPE>
             }
 
             int state;
-            TYPE* p = reinterpret_cast<TYPE*>(sipConvertToInstance(item, sipClass_TYPE, 0, SIP_NOT_NONE, &state, sipIsErr));
+            TYPE* p = reinterpret_cast<TYPE*>(sipConvertToType(item, sipType_TYPE, 0, SIP_NOT_NONE, &state, sipIsErr));
 
             if (!*sipIsErr)
             {
                 result_vector->push_back(*p);
             }
 
-            sipReleaseInstance(p, sipClass_TYPE, state);
+            sipReleaseType(p, sipType_TYPE, state);
             Py_DECREF(item);
         }
 


### PR DESCRIPTION
sipConvertToInstance and the like have been deprecated since Sip 4.8.0
and are removed with Sip 5.

As the old functions are already implemented as typedefs to the new
functions in Sip 4, there are no functional changes.

Deprecation reference:
https://docs.huihoo.com/pyqt/sip4/c_api.html#c.sipConvertToInstance

Related to #26