### PR TITLE
Store and preserve metadata

### DIFF
--- a/python/MetadataEntry.sip
+++ b/python/MetadataEntry.sip
@@ -16,28 +16,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-%Module(name = Savitar, call_super_init = True)
-
-%Include Types.sip
-%Include MetadataEntry.sip
-%Include SceneNode.sip
-%Include Scene.sip
-%Include MeshData.sip
-
-%ModuleHeaderCode
-namespace Savitar{} //Ensure that the namespace already exists
-using namespace Savitar;
-%End
-
-class ThreeMFParser
+class MetadataEntry
 {
     %TypeHeaderCode
-    #include "ThreeMFParser.h"
+    #include "MetadataEntry.h"
     %End
 
 public:
-    ThreeMFParser();
-    virtual ~ThreeMFParser();
-    Scene parse(std::string xml_string);
-    std::string sceneToString(Scene scene);
+    MetadataEntry(std::string value);
+    MetadataEntry(std::string value, std::string type);
+    MetadataEntry(std::string value, std::string type, bool preserve);
+
+    std::string value;
+    std::string type;
+    bool preserve;
 };

--- a/python/Scene.sip
+++ b/python/Scene.sip
@@ -31,6 +31,7 @@ public:
     void addSceneNode(SceneNode* node /Transfer/);
 
     std::map<std::string, std::string> getMetadata();
+    void setMetaDataEntry(std::string key, std::string value);
 
     std::string getUnit();
     void setUnit(std::string unit);

--- a/python/Scene.sip
+++ b/python/Scene.sip
@@ -1,7 +1,7 @@
 /*
  * This file is part of libSavitar
  *
- * Copyright (C) 2017 Ultimaker b.v. <j.vankessel@ultimaker.com>
+ * Copyright (C) 2021 Ultimaker B.V. <j.vankessel@ultimaker.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/python/Scene.sip
+++ b/python/Scene.sip
@@ -30,8 +30,10 @@ public:
 
     void addSceneNode(SceneNode* node /Transfer/);
 
-    std::map<std::string, std::string> getMetadata();
+    std::map<std::string, MetadataEntry> getMetadata();
     void setMetaDataEntry(std::string key, std::string value);
+    void setMetaDataEntry(std::string key, std::string value, std::string type);
+    void setMetaDataEntry(std::string key, std::string value, std::string type, bool preserve);
 
     std::string getUnit();
     void setUnit(std::string unit);

--- a/python/Scene.sip
+++ b/python/Scene.sip
@@ -31,6 +31,7 @@ public:
     void addSceneNode(SceneNode* node /Transfer/);
 
     std::map<std::string, MetadataEntry> getMetadata();
+    void setMetaDataEntry(std::string key, MetadataEntry entry);
     void setMetaDataEntry(std::string key, std::string value);
     void setMetaDataEntry(std::string key, std::string value, std::string type);
     void setMetaDataEntry(std::string key, std::string value, std::string type, bool preserve);

--- a/python/SceneNode.sip
+++ b/python/SceneNode.sip
@@ -38,8 +38,10 @@ public:
     std::string getId();
     void setId(std::string id);
 
-    std::map<std::string, std::string> getSettings();
+    std::map<std::string, MetadataEntry> getSettings();
     void setSetting(std::string key, std::string value);
+    void setSetting(std::string key, std::string value, std::string type);
+    void setSetting(std::string key, std::string value, std::string type, bool preserve);
 
     bool addChild(SceneNode* child /Transfer/);
     

--- a/python/SceneNode.sip
+++ b/python/SceneNode.sip
@@ -39,6 +39,7 @@ public:
     void setId(std::string id);
 
     std::map<std::string, MetadataEntry> getSettings();
+    void setSetting(std::string key, MetadataEntry entry);
     void setSetting(std::string key, std::string value);
     void setSetting(std::string key, std::string value, std::string type);
     void setSetting(std::string key, std::string value, std::string type, bool preserve);

--- a/python/Types.sip
+++ b/python/Types.sip
@@ -445,11 +445,11 @@ template<TYPE>
 
         while(i != sipCpp->end())
         {
-            std::string *key = new std::string((*i).first);
-            MetadataEntry *value = new MetadataEntry((*i).second);
+            std::string* key = new std::string((*i).first);
+            MetadataEntry* value = new MetadataEntry((*i).second);
 
             PyObject *key_object = sipConvertFromNewType(key, sipType_std_string, sipTransferObj);
-            PyObject *value_object = sipConvertFromNewType(value, sipType_std_string, sipTransferObj);
+            PyObject *value_object = sipConvertFromInstance(value, sipClass_MetadataEntry, sipTransferObj);
 
             if (key_object == NULL || value_object == NULL || PyDict_SetItem(result_dict, key_object, value_object) < 0)
             {
@@ -504,7 +504,7 @@ template<TYPE>
                     return 0;
                 }
 
-                if (!sipCanConvertToType(value_object, sipType_std_string, SIP_NOT_NONE))
+                if (!sipCanConvertToInstance(value_object, sipClass_MetadataEntry, SIP_NOT_NONE))
                 {
                     return 0;
                 }
@@ -520,12 +520,12 @@ template<TYPE>
             int key_state, value_state;
 
             std::string *key = reinterpret_cast<std::string *>(sipConvertToType(key_object, sipType_std_string, sipTransferObj, SIP_NOT_NONE, &key_state, sipIsErr));
-            MetadataEntry *value = reinterpret_cast<MetadataEntry*>(sipConvertToType(value_object, sipType_std_string, sipTransferObj, SIP_NOT_NONE, &value_state, sipIsErr));
+            MetadataEntry *value = reinterpret_cast<MetadataEntry*>(sipConvertToInstance(value_object, sipClass_MetadataEntry, 0, SIP_NOT_NONE, &value_state, sipIsErr));
 
             if (*sipIsErr)
             {
                 sipReleaseType(key, sipType_std_string, key_state);
-                sipReleaseType(value, sipType_std_string, value_state);
+                sipReleaseInstance(value, sipClass_MetadataEntry, value_state);
 
                 delete std_map;
                 return 0;

--- a/python/Types.sip
+++ b/python/Types.sip
@@ -2,7 +2,7 @@
  * This file is part of libSavitar.
  *
  * Parts of this code have been copied from libArcus
- * Copyright (C) 2016 Ultimaker b.v. <a.hiemstra@ultimaker.com>
+ * Copyright (C) 2021 Ultimaker B.V. <r.dulek@ultimaker.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -407,6 +407,131 @@ template<TYPE>
             }
 
             (*std_map)[*key] = *value;
+
+            sipReleaseType(key, sipType_std_string, key_state);
+            sipReleaseType(value, sipType_std_string, value_state);
+        }
+
+        *sipCppPtr = std_map;
+
+        return sipGetState(sipTransferObj);
+    %End
+};
+
+
+
+
+/**
+ * Convert a (Python) dict of metadata entries to std::map of MetadataEntry
+ * objects.
+ */
+%MappedType std::map<std::string, MetadataEntry>
+{
+    %TypeHeaderCode
+    #include <map>
+    %End
+
+    %ConvertFromTypeCode // From C++ to python
+        // Create the dictionary.
+        PyObject *result_dict = PyDict_New();
+
+        if (!result_dict)
+        {
+            return NULL;
+        }
+
+        // Set the dictionary elements.
+        std::map<std::string, MetadataEntry>::const_iterator i = sipCpp->begin();
+
+        while(i != sipCpp->end())
+        {
+            std::string *key = new std::string((*i).first);
+            MetadataEntry *value = new MetadataEntry((*i).second);
+
+            PyObject *key_object = sipConvertFromNewType(key, sipType_std_string, sipTransferObj);
+            PyObject *value_object = sipConvertFromNewType(value, sipType_std_string, sipTransferObj);
+
+            if (key_object == NULL || value_object == NULL || PyDict_SetItem(result_dict, key_object, value_object) < 0)
+            {
+                Py_DECREF(result_dict);
+
+                if (key_object)
+                {
+                    Py_DECREF(key_object);
+                }
+                else
+                {
+                    delete key;
+                }
+
+                if (value_object)
+                {
+                    Py_DECREF(value_object);
+                }
+                else
+                {
+                    delete value;
+                }
+
+                return nullptr;
+            }
+
+            Py_DECREF(key_object);
+            Py_DECREF(value_object);
+
+            ++i;
+        }
+
+        return result_dict;
+    %End
+
+    %ConvertToTypeCode // From python to C++
+        PyObject *key_object, *value_object;
+        SIP_SSIZE_T i = 0;
+
+        // Check the type if that is all that is required.
+        if (sipIsErr == nullptr)
+        {
+            if (!PyDict_Check(sipPy))
+            {
+                return 0;
+            }
+
+            while (PyDict_Next(sipPy, &i, &key_object, &value_object))
+            {
+                if (!sipCanConvertToType(key_object, sipType_std_string, SIP_NOT_NONE))
+                {
+                    return 0;
+                }
+
+                if (!sipCanConvertToType(value_object, sipType_std_string, SIP_NOT_NONE))
+                {
+                    return 0;
+                }
+            }
+
+            return 1;
+        }
+
+        std::map<std::string, MetadataEntry> *std_map = new std::map<std::string, MetadataEntry>;
+
+        while (PyDict_Next(sipPy, &i, &key_object, &value_object))
+        {
+            int key_state, value_state;
+
+            std::string *key = reinterpret_cast<std::string *>(sipConvertToType(key_object, sipType_std_string, sipTransferObj, SIP_NOT_NONE, &key_state, sipIsErr));
+            MetadataEntry *value = reinterpret_cast<MetadataEntry*>(sipConvertToType(value_object, sipType_std_string, sipTransferObj, SIP_NOT_NONE, &value_state, sipIsErr));
+
+            if (*sipIsErr)
+            {
+                sipReleaseType(key, sipType_std_string, key_state);
+                sipReleaseType(value, sipType_std_string, value_state);
+
+                delete std_map;
+                return 0;
+            }
+
+            (*std_map).emplace(*key, *value);
 
             sipReleaseType(key, sipType_std_string, key_state);
             sipReleaseType(value, sipType_std_string, value_state);

--- a/src/MetadataEntry.h
+++ b/src/MetadataEntry.h
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include "SavitarExport.h"
+
 namespace Savitar
 {
 
@@ -47,15 +49,15 @@ struct SAVITAR_EXPORT MetadataEntry
     std::string type;
 
     /*!
-     * Whether the data must be preserved when saving the scene to a new 3MF
+     * Whether the data should be preserved when saving the scene to a new 3MF
      * document.
      */
-    bool must_preserve;
+    bool preserve;
 
-    MetadataEntry(const std::string& value, const std::string& type, const bool must_preserve)
+    MetadataEntry(const std::string& value, const std::string& type = "xs:string", const bool preserve = false)
         : value(value)
         , type(type)
-        , must_preserve(must_preserve)
+        , preserve(preserve)
     {}
 };
 

--- a/src/MetadataEntry.h
+++ b/src/MetadataEntry.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of libSavitar
+ *
+ * Copyright (C) 2021 Ultimaker B.V. <j.vankessel@ultimaker.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef METADATAENTRY_H
+#define METADATAENTRY_H
+
+#include <string>
+
+namespace Savitar
+{
+
+/*!
+ * Represents an entry of metadata from 3MF documents.
+ *
+ * These entries are stored by a key in scenes and scene nodes.
+ */
+struct SAVITAR_EXPORT MetadataEntry
+{
+    /*!
+     * The value of the metadata entry.
+     *
+     * Regardless of the actual type, this value will be stored in serialised
+     * form here. The user of the 3MF data will need to interpret the data as
+     * is.
+     */
+    std::string value;
+
+    /*!
+     * The type of value. Must be an "XML type" as specified by the ODF, e.g.
+     * "xs:string" for text.
+     */
+    std::string type;
+
+    /*!
+     * Whether the data must be preserved when saving the scene to a new 3MF
+     * document.
+     */
+    bool must_preserve;
+
+    MetadataEntry(const std::string& value, const std::string& type, const bool must_preserve)
+        : value(value)
+        , type(type)
+        , must_preserve(must_preserve)
+    {}
+};
+
+}
+
+#endif

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -56,7 +56,16 @@ void Scene::fillByXMLNode(pugi::xml_node xml_node)
     // Handle metadata:
     for(pugi::xml_node metadata_node = xml_node.child("metadata"); metadata_node; metadata_node = metadata_node.next_sibling("metadata"))
     {
-        setMetaDataEntry(metadata_node.attribute("name").as_string(), metadata_node.text().as_string());
+        const std::string key = metadata_node.attribute("name").as_string();
+        const std::string value = metadata_node.text().as_string();
+        std::string type = metadata_node.attribute("type").as_string();
+        if(type == "")
+        {
+            type = "xs:string"; //Fill in the default type if it's not present.
+        }
+        const std::string preserve_str = metadata_node.attribute("preserve").as_string(); //Don't use as_bool since 3MF's boolean parsing is more lenient.
+        const bool preserve = (preserve_str != "" && preserve_str != "0");
+        setMetaDataEntry(key, value, type, preserve);
     }
 
     pugi::xml_node build = xml_node.child("build");

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -178,6 +178,11 @@ std::vector<SceneNode*> Scene::getAllSceneNodes()
     return all_nodes;
 }
 
+void Scene::setMetaDataEntry(const std::string& key, const MetadataEntry& entry)
+{
+    metadata.emplace(key, entry);
+}
+
 void Scene::setMetaDataEntry(const std::string& key, const std::string& value, const std::string& type, const bool preserve)
 {
     metadata.emplace(key, MetadataEntry(value, type, preserve));

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -68,6 +68,18 @@ void Scene::fillByXMLNode(pugi::xml_node xml_node)
         {
             SceneNode* temp_scene_node = createSceneNodeFromObject(xml_node, object_node);
             temp_scene_node->setTransformation(item.attribute("transform").as_string());
+            
+            // Get all metadata from the item and update that.
+            const pugi::xml_node metadatagroup_node = item.child("metadatagroup");
+            if (metadatagroup_node)
+            {
+                for (pugi::xml_node setting = metadatagroup_node.child("metadata"); setting; setting = setting.next_sibling("metadata"))
+                {
+                    std::string key = setting.attribute("name").as_string();
+                    temp_scene_node->setSetting(key, setting.text().as_string());
+                }
+            }
+            
             scene_nodes.push_back(temp_scene_node);
         }
         else

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libSavitar
  *
- * Copyright (C) 2017 Ultimaker b.v. <j.vankessel@ultimaker.com>
+ * Copyright (C) 2021 Ultimaker B.V. <j.vankessel@ultimaker.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -161,9 +161,9 @@ std::vector<SceneNode*> Scene::getAllSceneNodes()
     return all_nodes;
 }
 
-void Scene::setMetaDataEntry(std::string key, std::string value)
+void Scene::setMetaDataEntry(const std::string& key, const std::string& value, const std::string& type, const bool preserve)
 {
-    metadata[key] = value;
+    metadata.emplace(key, MetadataEntry(value, type, preserve));
 }
 
 std::string Scene::getUnit()
@@ -171,7 +171,7 @@ std::string Scene::getUnit()
     return unit;
 }
 
-std::map< std::string, std::string > Scene::getMetadata()
+const std::map<std::string, MetadataEntry>& Scene::getMetadata() const
 {
     return metadata;
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -75,8 +75,16 @@ void Scene::fillByXMLNode(pugi::xml_node xml_node)
             {
                 for (pugi::xml_node setting = metadatagroup_node.child("metadata"); setting; setting = setting.next_sibling("metadata"))
                 {
-                    std::string key = setting.attribute("name").as_string();
-                    temp_scene_node->setSetting(key, setting.text().as_string());
+                    const std::string key = setting.attribute("name").as_string();
+                    const std::string value = setting.text().as_string();
+                    std::string type = setting.attribute("type").as_string();
+                    if(type == "") //Not specified.
+                    {
+                        type = "xs:string";
+                    }
+                    const std::string preserve_str = setting.attribute("preserve").as_string(); //Needs to be true if string is not "0", which is less strict than .as_bool();
+                    const bool preserve = (preserve_str != "" && preserve_str != "0");
+                    temp_scene_node->setSetting(key, value, type, preserve);
                 }
             }
             

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -103,7 +103,7 @@ SceneNode* Scene::createSceneNodeFromObject(pugi::xml_node root_node, pugi::xml_
     
     if(has_mesh_node)
     {
-        mesh_node_object_id = scene_node->getSettings()["mesh_node_objectid"];
+        mesh_node_object_id = scene_node->getSettings().at("mesh_node_objectid").value;
     }
 
     // We have to do the checking for children outside of the SceneNode creation itself, because it only has references.

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libSavitar
  *
- * Copyright (C) 2017 Ultimaker b.v. <j.vankessel@ultimaker.com>
+ * Copyright (C) 2021 Ultimaker B.V. <j.vankessel@ultimaker.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -69,12 +69,12 @@ namespace Savitar
          * \param key The key of the meta data.
          * \param value The value of the meta data.
          */
-        void setMetaDataEntry(std::string key, std::string value);
+        void setMetaDataEntry(const std::string& key, const std::string& value, const std::string& type = "xs:string", const bool preserve = false);
 
         /**
          * Get all meta data entries
          */
-        std::map<std::string, std::string> getMetadata();
+        const std::map<std::string, MetadataEntry>& getMetadata() const;
 
         /**
         * Get the unit (milimeter, inch, etc) of the scene.
@@ -86,7 +86,7 @@ namespace Savitar
 
     protected:
         std::vector< SceneNode*> scene_nodes;
-        std::map<std::string, std::string> metadata;
+        std::map<std::string, MetadataEntry> metadata;
         std::string unit;
 
         /**

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -62,12 +62,23 @@ namespace Savitar
         void fillByXMLNode(pugi::xml_node xml_node);
 
         /**
+         * Store a metadata entry as metadata.
+         * @param key The key of the metadata.
+         * @param entry A MetadataEntry object containing metadata and
+         * additional properties.
+         */
+        void setMetaDataEntry(const std::string& key, const MetadataEntry& entry);
+
+        /**
          * Set a meta data entry of the scene.
          *
          * Note that this not adhere to the full 3mf spec yet. All keys are accepted.
          *
-         * \param key The key of the meta data.
-         * \param value The value of the meta data.
+         * \param key The key of the metadata.
+         * \param value The value of the metadata.
+         * \param type The data type of the metadata.
+         * \param preserve Whether the metadata entry needs to be preserved
+         * through save-load loops of the 3MF document.
          */
         void setMetaDataEntry(const std::string& key, const std::string& value, const std::string& type = "xs:string", const bool preserve = false);
 

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libSavitar
  *
- * Copyright (C) 2017 Ultimaker b.v. <j.vankessel@ultimaker.com>
+ * Copyright (C) 2021 Ultimaker B.V. <j.vankessel@ultimaker.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -116,7 +116,7 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
         {
             const std::string key = setting.attribute("key").as_string();
             const std::string value = setting.text().as_string();
-            settings[key] = value;
+            setSetting(key, value);
         }
     }
 
@@ -143,7 +143,8 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
 
             key = (pos != std::string::npos) ? key.substr(pos + 1) : key;
             const std::string value = setting.text().as_string();
-            settings[key] = value;
+            //TODO: Read type and preserve.
+            setSetting(key, value);
         }
     }
 }
@@ -168,14 +169,14 @@ void SceneNode::setName(std::string name)
     this->name = name;
 }
 
-std::map< std::string, std::string > SceneNode::getSettings()
+const std::map<std::string, MetadataEntry>& SceneNode::getSettings() const
 {
     return settings;
 }
 
-void SceneNode::setSetting(std::string key, std::string value)
+void SceneNode::setSetting(const std::string& key, const std::string& value, const std::string& type, const bool preserve)
 {
-    settings[key] = value;
+    settings.emplace(key, MetadataEntry(value, type, preserve));
 }
 
 void SceneNode::removeSetting(std::string key)

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -143,8 +143,14 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
 
             key = (pos != std::string::npos) ? key.substr(pos + 1) : key;
             const std::string value = setting.text().as_string();
-            //TODO: Read type and preserve.
-            setSetting(key, value);
+            std::string type = setting.attribute("type").as_string();
+            if(type == "")
+            {
+                type = "xs:string";
+            }
+            std::string preserve_str = setting.attribute("preserve").as_string(); //as_bool is too strict. Any non-zero value evaluates as true. Parse this ourselves.
+            const bool preserve = (preserve_str != "" && preserve_str != "0");
+            setSetting(key, value, type, preserve);
         }
     }
 }

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -180,6 +180,11 @@ const std::map<std::string, MetadataEntry>& SceneNode::getSettings() const
     return settings;
 }
 
+void SceneNode::setSetting(const std::string& key, const MetadataEntry& entry)
+{
+    settings.emplace(key, entry);
+}
+
 void SceneNode::setSetting(const std::string& key, const std::string& value, const std::string& type, const bool preserve)
 {
     settings.emplace(key, MetadataEntry(value, type, preserve));

--- a/src/SceneNode.cpp
+++ b/src/SceneNode.cpp
@@ -135,13 +135,11 @@ void SceneNode::fillByXMLNode(pugi::xml_node xml_node)
             std::string key = setting.attribute("name").as_string();
             const size_t pos = key.find_first_of(':');
 
-            // Only accept namespaces cura and implied 'default':
-            if (pos != std::string::npos && cura_equivalent_namespaces.count(key.substr(0, pos)) < 1)
+            //Make 'cura' namespace behave like the default.
+            if (pos != std::string::npos && cura_equivalent_namespaces.count(key.substr(0, pos)) == 1)
             {
-                continue;
+                key = key.substr(pos + 1);
             }
-
-            key = (pos != std::string::npos) ? key.substr(pos + 1) : key;
             const std::string value = setting.text().as_string();
             std::string type = setting.attribute("type").as_string();
             if(type == "")

--- a/src/SceneNode.h
+++ b/src/SceneNode.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libSavitar
  *
- * Copyright (C) 2017 Ultimaker b.v. <j.vankessel@ultimaker.com>
+ * Copyright (C) 2021 Ultimaker B.V. <j.vankessel@ultimaker.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -21,6 +21,7 @@
 
 #include "SavitarExport.h"
 #include "MeshData.h"
+#include "MetadataEntry.h"
 
 #include <string>
 #include <vector>
@@ -72,11 +73,11 @@ namespace Savitar
          * Get the (per-object) settings attached to this SceneNode.
          * Note that this is part of the Cura Extension and not 3mf Core.
          */
-        std::map<std::string, std::string> getSettings();
+        const std::map<std::string, MetadataEntry>& getSettings() const;
 
-        void setSetting(std::string key, std::string value);
+        void setSetting(const std::string& key, const std::string& value, const std::string& type = "xs:string", const bool preserve = false);
         void removeSetting(std::string key);
-        
+
         /**
          * Type of the scene node. Can be "model", "solidsupport", "support", "surface", or "other". 
          * This defaults to "model"
@@ -90,7 +91,7 @@ namespace Savitar
         std::string transformation;
         std::vector<SceneNode*> children;
         MeshData mesh_data;
-        std::map<std::string, std::string> settings;
+        std::map<std::string, MetadataEntry> settings;
         std::string id;
         std::string name;
         std::string type;

--- a/src/SceneNode.h
+++ b/src/SceneNode.h
@@ -75,6 +75,7 @@ namespace Savitar
          */
         const std::map<std::string, MetadataEntry>& getSettings() const;
 
+        void setSetting(const std::string& key, const MetadataEntry& entry);
         void setSetting(const std::string& key, const std::string& value, const std::string& type = "xs:string", const bool preserve = false);
         void removeSetting(std::string key);
 

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -77,16 +77,16 @@ std::string ThreeMFParser::sceneToString(Scene scene)
         }
         object.append_attribute("type") = scene_node->getType().c_str();
 
-        std::map<std::string, std::string> per_object_settings = scene_node->getSettings();
+        const std::map<std::string, MetadataEntry>& per_object_settings = scene_node->getSettings();
         if(!per_object_settings.empty())
         {
             pugi::xml_node settings = object.append_child("metadatagroup");
-            for(const std::pair<std::string, std::string> setting_pair: per_object_settings)
+            for(const std::pair<std::string, MetadataEntry>& setting_pair: per_object_settings)
             {
                 pugi::xml_node setting = settings.append_child("metadata");
                 setting.append_attribute("name") = (std::string("cura:") + setting_pair.first).c_str();
-                setting.text().set(setting_pair.second.c_str());
-                setting.append_attribute("preserve") = "true";
+                setting.text().set(setting_pair.second.value.c_str());
+                setting.append_attribute("preserve") = "true"; //TODO: Write correct preserve and type.
                 setting.append_attribute("type") = "xs:string";
             }
         }

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -84,7 +84,7 @@ std::string ThreeMFParser::sceneToString(Scene scene)
             for(const std::pair<std::string, MetadataEntry>& setting_pair: per_object_settings)
             {
                 pugi::xml_node setting = settings.append_child("metadata");
-                setting.append_attribute("name") = (std::string("cura:") + setting_pair.first).c_str();
+                setting.append_attribute("name") = setting_pair.first.c_str();
                 setting.text().set(setting_pair.second.value.c_str());
                 if(setting_pair.second.type != "xs:string") //xs:string is the default type and doesn't need to be written.
                 {

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -86,8 +86,14 @@ std::string ThreeMFParser::sceneToString(Scene scene)
                 pugi::xml_node setting = settings.append_child("metadata");
                 setting.append_attribute("name") = (std::string("cura:") + setting_pair.first).c_str();
                 setting.text().set(setting_pair.second.value.c_str());
-                setting.append_attribute("preserve") = "true"; //TODO: Write correct preserve and type.
-                setting.append_attribute("type") = "xs:string";
+                if(setting_pair.second.type != "xs:string") //xs:string is the default type and doesn't need to be written.
+                {
+                    setting.append_attribute("type") = setting_pair.second.type.c_str();
+                }
+                if(setting_pair.second.preserve)
+                {
+                    setting.append_attribute("preserve") = "true";
+                }
             }
         }
         
@@ -117,7 +123,6 @@ std::string ThreeMFParser::sceneToString(Scene scene)
             mesh_node_setting.append_attribute("name") = "mesh_node_objectid";
             mesh_node_setting.text().set(scene_node->getMeshNode()->getId().c_str());
             mesh_node_setting.append_attribute("preserve") = "true";
-            mesh_node_setting.append_attribute("type") = "xs:string";
         }
     }
 
@@ -133,7 +138,14 @@ std::string ThreeMFParser::sceneToString(Scene scene)
         pugi::xml_node metadata_node = model_node.append_child("metadata");
         metadata_node.append_attribute("name") = metadata_pair.first.c_str();
         metadata_node.text().set(metadata_pair.second.value.c_str());
-        //TODO: Set other metadata properties for type and preserve.
+        if(metadata_pair.second.type != "xs:string") //xs:string is the default and doesn't need to get written then.
+        {
+            metadata_node.append_attribute("type") = metadata_pair.second.type.c_str();
+        }
+        if(metadata_pair.second.preserve)
+        {
+            metadata_node.append_attribute("preserve") = "true";
+        }
     }
     
     std::stringstream ss;

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -128,11 +128,12 @@ std::string ThreeMFParser::sceneToString(Scene scene)
         item.append_attribute("transform") = scene_node->getTransformation().c_str();
     }
     
-    for(const std::pair<std::string, std::string> metadata_pair: scene.getMetadata())
+    for(const std::pair<std::string, MetadataEntry>& metadata_pair: scene.getMetadata())
     {
         pugi::xml_node metadata_node = model_node.append_child("metadata");
         metadata_node.append_attribute("name") = metadata_pair.first.c_str();
-        metadata_node.text().set(metadata_pair.second.c_str());
+        metadata_node.text().set(metadata_pair.second.value.c_str());
+        //TODO: Set other metadata properties for type and preserve.
     }
     
     std::stringstream ss;

--- a/src/ThreeMFParser.cpp
+++ b/src/ThreeMFParser.cpp
@@ -59,7 +59,7 @@ std::string ThreeMFParser::sceneToString(Scene scene)
     model_node.append_attribute("xmlns") = xml_namespace::getDefaultUri().c_str();
     model_node.append_attribute("xmlns:cura") = xml_namespace::getCuraUri().c_str();
     model_node.append_attribute("xml:lang") ="en-US";
-
+    
     for(int i = 0; i < scene.getAllSceneNodes().size(); i++)
     {
         SceneNode* scene_node = scene.getAllSceneNodes().at(i);
@@ -127,7 +127,14 @@ std::string ThreeMFParser::sceneToString(Scene scene)
         item.append_attribute("objectid") = scene_node->getId().c_str();
         item.append_attribute("transform") = scene_node->getTransformation().c_str();
     }
-
+    
+    for(const std::pair<std::string, std::string> metadata_pair: scene.getMetadata())
+    {
+        pugi::xml_node metadata_node = model_node.append_child("metadata");
+        metadata_node.append_attribute("name") = metadata_pair.first.c_str();
+        metadata_node.text().set(metadata_pair.second.c_str());
+    }
+    
     std::stringstream ss;
     document.save(ss);
     return ss.str();

--- a/tests/ThreeMFParserTest.cpp
+++ b/tests/ThreeMFParserTest.cpp
@@ -81,13 +81,13 @@ TEST_F(ThreeMFParserTest, parse)
     }
     // NOTE: To/from for content of vertices/triangles is tested in MeshDataTest.
 
-    std::map<std::string, std::string> settings;
+    std::map<std::string, MetadataEntry> settings;
 
     settings = nodes[0]->getSettings();
     EXPECT_NE(settings.find("extruder_nr"), settings.end());
-    EXPECT_EQ(settings["extruder_nr"].compare("0"), 0);
+    EXPECT_EQ(settings.at("extruder_nr").value.compare("0"), 0);
     EXPECT_NE(settings.find("bottom_layers"), settings.end());
-    EXPECT_EQ(settings["bottom_layers"].compare("20"), 0);
+    EXPECT_EQ(settings.at("bottom_layers").value.compare("20"), 0);
     EXPECT_EQ(settings.find("infill_pattern"), settings.end());
 
     settings = nodes[1]->getSettings();
@@ -95,10 +95,10 @@ TEST_F(ThreeMFParserTest, parse)
 
     settings = nodes[2]->getSettings();
     EXPECT_NE(settings.find("extruder_nr"), settings.end());
-    EXPECT_EQ(settings["extruder_nr"].compare("1"), 0);
+    EXPECT_EQ(settings.at("extruder_nr").value.compare("1"), 0);
     EXPECT_EQ(settings.find("bottom_layers"), settings.end());
     EXPECT_NE(settings.find("infill_pattern"), settings.end());
-    EXPECT_EQ(settings["infill_pattern"].compare("concentric"), 0);
+    EXPECT_EQ(settings.at("infill_pattern").value.compare("concentric"), 0);
 
     EXPECT_EQ(nodes[0]->getName().compare("test_object"), 0);
     EXPECT_EQ(nodes[1]->getName().compare(""), 0);


### PR DESCRIPTION
This pull request allows metadata from 3MF documents to be stored in the scene, and allows adding new metadata from the user of the library.

Contributes to issue CURA-7615.