### PR TITLE
CMake should sse find FindPython3  if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,18 @@ add_subdirectory(pugixml)
 if(BUILD_PYTHON)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-    # FIXME: Use FindPython3 to find Python, new in CMake 3.12.
-    # However currently on our CI server it finds the wrong Python version and then doesn't find the headers.
-    find_package(PythonInterp 3.4 REQUIRED)
-    find_package(PythonLibs 3.4 REQUIRED)
+    # FIXME: Remove the code for CMake <3.12 once we have switched over completely.
+    # FindPython3 is a new module since CMake 3.12. It deprecates FindPythonInterp and FindPythonLibs.
+    if(${CMAKE_VERSION} VERSION_LESS 3.12)
+        # FIXME: Use FindPython3 to find Python, new in CMake 3.12.
+        # However currently on our CI server it finds the wrong Python version and then doesn't find the headers.
+        find_package(PythonInterp 3.4 REQUIRED)
+        find_package(PythonLibs 3.4 REQUIRED)
+
+    else()
+        # Use FindPython3 for CMake >=3.12
+        find_package(Python3 3.4 REQUIRED COMPONENTS Interpreter Development)
+    endif()
 
     find_package(SIP REQUIRED)
     if(NOT DEFINED LIB_SUFFIX)

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PROJECT_DIR="$( cd "${SCRIPT_DIR}/.." && pwd )"
 
 # Make sure that environment variables are set properly
-source /opt/rh/devtoolset-7/enable
+source /opt/rh/devtoolset-8/enable
 export PATH="${CURA_BUILD_ENV_PATH}/bin:${PATH}"
 export PKG_CONFIG_PATH="${CURA_BUILD_ENV_PATH}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 


### PR DESCRIPTION
This allows us to use FindPython3 if the cmake version
is higher or equal to 3.12. Which allows a user to set
-DPython3_FIND_VIRTUALENV=ONLY such that the library
can be installed in a virtual environment (mostly
useful on Mac and Windows machines). This commit
doesn't break the current behavior of our CI machines.

Also updated the devtools to version 8