### PR TITLE
CURA-8146: Fix getting PyCapsule error on import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 if(BUILD_PYTHON)
     set(SIP_EXTRA_FILES_DEPEND python/Types.sip python/MeshData.sip python/SceneNode.sip python/Scene.sip)
     #set(SIP_EXTRA_SOURCE_FILES python/Types.cpp)
-    set(SIP_EXTRA_OPTIONS -g) # -g means always release the GIL before calling C++ methods.
+    set(SIP_EXTRA_OPTIONS -g -n PyQt5.sip) # -g means always release the GIL before calling C++ methods. -n PyQt5.sip is required to not get the PyCapsule error
     add_sip_python_module(Savitar python/ThreeMFParser.sip Savitar)
 endif()
 


### PR DESCRIPTION
This fix overcomes the notorious `ValueError: PyCapsule_GetPointer called with incorrect name` that
we get if we do not import Arcus, Savitar, and pynest2d in cura_app.py (and other places) even if it
is not used.

All credits go to Rex Dieter for figuring that this missing flag was the issue.
https://src.fedoraproject.org/rpms/libarcus/pull-request/1#request_diff

CURA-8146